### PR TITLE
[ FEATURE ] 커스텀뷰를 활용하여 달력 화면 구현

### DIFF
--- a/app/src/main/java/com/example/plogging/ui/calender/CalenderFragment.kt
+++ b/app/src/main/java/com/example/plogging/ui/calender/CalenderFragment.kt
@@ -5,14 +5,32 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.example.plogging.R
+import androidx.fragment.app.viewModels
+import com.example.plogging.databinding.FragmentCarlenderBinding
 
 class CalenderFragment : Fragment() {
+
+    private var _binding: FragmentCarlenderBinding? = null
+    private val binding get() = _binding!!
+    private val viewmodel by viewModels<CalenderViewmodel> {
+        CalenderViewmodel.provideFactory()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.fragment_carlender, container, false)
+    ): View {
+        _binding = FragmentCarlenderBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        seyLayout()
+    }
+
+    private fun seyLayout() {
+        binding.viewmodel = viewmodel
+        binding.lifecycleOwner = viewLifecycleOwner
     }
 }

--- a/app/src/main/java/com/example/plogging/ui/calender/CalenderViewmodel.kt
+++ b/app/src/main/java/com/example/plogging/ui/calender/CalenderViewmodel.kt
@@ -1,0 +1,16 @@
+package com.example.plogging.ui.calender
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+
+class CalenderViewmodel : ViewModel() {
+
+    companion object {
+        fun provideFactory() = viewModelFactory {
+            initializer {
+                CalenderViewmodel()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/plogging/ui/customview/ParticipantsLayout.kt
+++ b/app/src/main/java/com/example/plogging/ui/customview/ParticipantsLayout.kt
@@ -1,0 +1,34 @@
+package com.example.plogging.ui.customview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.example.plogging.R
+import com.example.plogging.databinding.ViewParticitateinfolayoutBinding
+
+class ParticipantsLayout(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
+
+    private val binding: ViewParticitateinfolayoutBinding
+
+    init {
+        binding = ViewParticitateinfolayoutBinding.inflate(LayoutInflater.from(context), this, true)
+        context.theme.obtainStyledAttributes(attrs, R.styleable.ParticipantsLayout, 0, 0)
+            .use { array ->
+                val labelResId =
+                    array.getResourceId(R.styleable.ParticipantsLayout_participantsLabel, 0)
+                val ParticipantsCount =
+                    array.getResourceId(R.styleable.ParticipantsLayout_userCount, 0)
+                setInfoLabel(labelResId)
+                setParticipantsCount(ParticipantsCount)
+            }
+    }
+
+    private fun setInfoLabel(labelResId: Int) {
+        binding.tvUserCount.text = context.getText(labelResId)
+    }
+
+    private fun setParticipantsCount(count: Int) {
+        // TODO : recycler에 참가자 등록하기.
+    }
+}

--- a/app/src/main/java/com/example/plogging/ui/customview/UserInfoLayout.kt
+++ b/app/src/main/java/com/example/plogging/ui/customview/UserInfoLayout.kt
@@ -1,0 +1,32 @@
+package com.example.plogging.ui.customview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.example.plogging.R
+import com.example.plogging.databinding.ViewUserinfolayoutBinding
+
+class UserInfoLayout(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
+    private val binding: ViewUserinfolayoutBinding
+
+    init {
+        binding = ViewUserinfolayoutBinding.inflate(LayoutInflater.from(context), this, true)
+        context.theme.obtainStyledAttributes(attrs, R.styleable.UserInfoLayout, 0, 0)
+            .use { array ->
+                val labelResId = array.getResourceId(R.styleable.UserInfoLayout_userInfoLabel, 0)
+                val userProfile =
+                    array.getResourceId(R.styleable.UserInfoLayout_userProfileImage, 0)
+                setInfoLabel(labelResId)
+                setUserProfile(userProfile)
+            }
+    }
+
+    private fun setInfoLabel(labelResId: Int) {
+        binding.tvName.text = context.getString(labelResId)
+    }
+
+    private fun setUserProfile(userProfile: Int) {
+        // TODO :  binding adapter 의 displatImageRound 를 이용해야 함.
+    }
+}

--- a/app/src/main/res/layout/fragment_carlender.xml
+++ b/app/src/main/res/layout/fragment_carlender.xml
@@ -1,15 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewmodel"
+            type="com.example.plogging.ui.calender.CalenderViewmodel" />
+
+    </data>
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.calender.CalenderFragment">
 
-        <!-- TODO: Update blank fragment layout -->
-        <TextView
-            android:layout_width="match_parent"
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/card_container"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:textSize="100sp"
-            tools:text="달력화면" />
-    </FrameLayout>
+            android:layout_margin="16dp"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="10dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <CalendarView
+                android:id="@+id/calender"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_calender_recodes"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="@id/card_container"
+            app:layout_constraintStart_toStartOf="@id/card_container"
+            app:layout_constraintTop_toBottomOf="@id/card_container"
+            tools:listitem="@layout/item_calender_recode" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_calender_recode.xml
+++ b/app/src/main/res/layout/item_calender_recode.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="viewmodel"
+            type="com.example.plogging.ui.calender.CalenderViewmodel" />
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="20dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <com.example.plogging.ui.customview.UserInfoLayout
+                android:id="@+id/view_user_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.example.plogging.ui.customview.ParticipantsLayout
+                android:id="@+id/view_participants"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="@id/view_user_info"
+                app:layout_constraintTop_toBottomOf="@id/view_user_info" />
+
+            <ImageView
+                android:layout_width="0dp"
+                android:layout_height="60dp"
+                android:contentDescription="@string/thumbnail_photo"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/view_participants" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/app/src/main/res/layout/view_particitateinfolayout.xml
+++ b/app/src/main/res/layout/view_particitateinfolayout.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <data>
+
+        <variable
+            name="viewmodel"
+            type="com.example.plogging.ui.calender.CalenderViewmodel" />
+    </data>
+
+    <merge xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
+        <TextView
+            android:id="@+id/tv_user_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            tools:text="참가한 멤버 ( 1 / 10 )"
+            android:textColor="@color/black"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_users"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintStart_toStartOf="@id/tv_user_count"
+            app:layout_constraintTop_toBottomOf="@id/tv_user_count" />
+    </merge>
+</layout>

--- a/app/src/main/res/layout/view_userinfolayout.xml
+++ b/app/src/main/res/layout/view_userinfolayout.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+
+        <variable
+            name="viewmodel"
+            type="com.example.plogging.ui.calender.CalenderViewmodel" />
+    </data>
+
+    <merge xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
+        <ImageView
+            android:id="@+id/iv_profile"
+            android:layout_width="45dp"
+            android:layout_height="45dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:contentDescription="@string/user_profile_photo"
+            tools:src="@mipmap/ic_app_logo_avocado" />
+
+        <TextView
+            android:id="@+id/tv_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textColor="@color/black"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@id/iv_profile"
+            app:layout_constraintStart_toEndOf="@id/iv_profile"
+            app:layout_constraintTop_toTopOf="@id/iv_profile"
+            tools:text="Inah" />
+    </merge>
+</layout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="UserInfoLayout">
+        <attr name="userInfoLabel" format="reference" />
+        <attr name="userProfileImage" format="reference" />
+    </declare-styleable>
+
+    <declare-styleable name="ParticipantsLayout">
+        <attr name="participantsLabel" format="reference" />
+        <attr name="userCount" format="integer" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="tracking_noti_2">진행중 마커를 길게 눌러보세요</string>
     <string name="start_plogging_alone">혼자 플로깅 하기</string>
     <string name="user_profile_photo">user_profile_photo</string>
+    <string name="thumbnail_photo">Thumbnail_photo</string>
     <string name="my_info">내 정보</string>
     <string name="auth">계정</string>
     <string name="logout">로그아웃</string>


### PR DESCRIPTION
## 구현 내용
 - 사용자 정보를 나타내는 커스텀뷰 정의
 - 참가자들을 나타내는 커스텀뷰 정의
 - 달력 화면 recycler에 나타날 아이템을 커스텀뷰를 활용하려 정의
 - 달력 화면 Fragment 정의
 - 달력 화면과 viewmodel 연결


## 구현 사진

<img src="https://user-images.githubusercontent.com/95750706/226150678-d6b36fa1-ccaa-4a3e-b926-a60fdb49ce4d.png" width="40%">
